### PR TITLE
Use local package.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ const rewireDefinePlugin = require('react-app-rewire-define-plugin')
 
 // Use `webpack.DefinePlugin` to add the version number from package.json
 config = rewireDefinePlugin(config, env, {
-  'process.env.VERSION': JSON.stringify(require('package.json').version)
+  'process.env.VERSION': JSON.stringify(require('./package.json').version)
 })
 ```


### PR DESCRIPTION
using example in readme `npm start` fails complaining `Cannot find module 'package.json'`